### PR TITLE
Android and other compatibility issue fix

### DIFF
--- a/Engine/porting/Android/jni/Android/CAndroidRequest.cpp
+++ b/Engine/porting/Android/jni/Android/CAndroidRequest.cpp
@@ -768,7 +768,8 @@ bool
 CAndroidRequest::watchThread(void * hThread, s32 * status)
 {
 	PF_THREAD * pThread = (PF_THREAD *)hThread;
-	if(pthread_kill(pThread->id, 0) != ESRCH) {
+	int result = pthread_kill(pThread->id, 0);
+	if(result != ESRCH && result != EINVAL) {
 		return true;
 	}
 	*status = pThread->result;

--- a/Engine/porting/Android/jni/Android/CAndroidRequest.cpp
+++ b/Engine/porting/Android/jni/Android/CAndroidRequest.cpp
@@ -84,7 +84,10 @@ CAndroidRequest::~CAndroidRequest() {
 	delete [] m_homePath;
 	delete [] m_platform;
   delete [] m_regId;
-  KLBDELETEA(m_bundleVersion);
+  if (m_bundleVersion != NULL) {
+    delete[] m_bundleVersion;
+    m_bundleVersion = NULL;
+  }
 }
 
 CAndroidRequest *
@@ -120,7 +123,7 @@ void CAndroidRequest::initBundleVersion()
   callJavaMethod(value, "getVersionName", 'S', "");
   jstring jstr = (jstring)value.l;
   const char *str = CJNI::getJNIEnv()->GetStringUTFChars(jstr, NULL);
-  char *buf = KLBNEWA(char, strlen(str) + 1);
+  char *buf = new char[strlen(str) + 1];
   sprintf(buf, "%s", str);
   m_bundleVersion = (const char *)buf;
   CJNI::getJNIEnv()->ReleaseStringUTFChars(jstr, str);

--- a/Engine/porting/Android/jni/Android/CAndroidRequest.h
+++ b/Engine/porting/Android/jni/Android/CAndroidRequest.h
@@ -208,6 +208,9 @@ private:
 	static CAndroidRequest * ms_instance;
 	static void getElapsedTimeSpec(struct timespec * ts);
 	static s64 getElapsedNanoTime(void);
+  
+  const char* m_bundleVersion;
+  void initBundleVersion();
 };
 
 #endif // cppinterface_h

--- a/Engine/porting/Android/jni/Android/CAndroidRequest.h
+++ b/Engine/porting/Android/jni/Android/CAndroidRequest.h
@@ -206,8 +206,6 @@ private:
 	const char		*	m_regId;
 
 	static CAndroidRequest * ms_instance;
-	static void getElapsedTimeSpec(struct timespec * ts);
-	static s64 getElapsedNanoTime(void);
   
   const char* m_bundleVersion;
   void initBundleVersion();

--- a/Engine/porting/Android/src/klb/android/GameEngine/WebViewItem.java
+++ b/Engine/porting/Android/src/klb/android/GameEngine/WebViewItem.java
@@ -26,6 +26,7 @@ import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.widget.LinearLayout;
 import android.content.Context;
+import android.content.pm.PackageManager.NameNotFoundException;
 import android.graphics.Bitmap;
 import java.lang.String;
 import java.lang.System;
@@ -96,6 +97,9 @@ class WebViewItem
 		m_extraHeaders = new HashMap<String, String>();
 		m_extraHeaders.put("API-Model", "straightforward");
 		
+    try {
+      m_extraHeaders.put("Bundle-Version", context.getPackageManager().getPackageInfo(context.getPackageName(), 0).versionName);
+    } catch (NameNotFoundException e) {}
 		if(client != null) m_extraHeaders.put("Client-Version", client);
 		if(region != null) m_extraHeaders.put("Region",	region);
 		if(applicationId != null) m_extraHeaders.put("Application-ID", applicationId);

--- a/Engine/source/LuaLib/CKLBLuaLibTASK.cpp
+++ b/Engine/source/LuaLib/CKLBLuaLibTASK.cpp
@@ -115,7 +115,12 @@ CKLBLuaLibTASK::isKill(lua_State * L)
 	if(!lua.isNil(1)) {
 		CKLBLuaTask * pTask = (CKLBLuaTask *)lua.getPointer(1);
 		if(!pTask) return 0;
-		CHECKTASK(pTask);
+		//ERROR the cancelled task was specified
+		//CHECKTASK(pTask);
+		if (!CKLBTaskMgr::getInstance().isExistTask(pTask)) {
+			lua.retBool(true);
+			return 1;
+		}
 		CKLBTaskMgr& mgr = CKLBTaskMgr::getInstance();
 		isRemove = mgr.is_remove(pTask);
 	}


### PR DESCRIPTION
Here are some fix for some known issues taken from my old Playground repo

(Please try compile before merge, I don't have Android develop environment for now so I can't do that by myself)

Following fixes included:
 - Fix `CAndroidRequest::getBundleVersion()` returns wild pointer (randomly cause `login/authkey` request send a garbled `Bundle-Version`)
 - Fix Android 6.0 `failed to fetch alarm clock via ioctl`
 - Fix Android 5.0+ update download hang up
 - Fix `TASK_isKill` throws `ERROR the cancelled task was specified` (that acturally happens when running LLSIF)
 - Add `Bundle-Version` header for Android WebView (Official client sends that)